### PR TITLE
Fix CRC not updated in UpdateHeight

### DIFF
--- a/src/PngImageWriter.cs
+++ b/src/PngImageWriter.cs
@@ -139,6 +139,15 @@ namespace ZXing.PngWriter
             var position = stream.Position;
             stream.Position = _heightPosition;
             stream.WriteUInt((uint)height);
+
+            // Recalculate CRC over chunk type (4 bytes) + chunk data (13 bytes)
+            var chunkTypePosition = _heightPosition - 8;
+            stream.Position = chunkTypePosition;
+            Span<byte> typeAndData = stackalloc byte[4 + 13];
+            stream.Read(typeAndData);
+            var crcHash = CRC.Crc32(typeAndData);
+            stream.WriteUInt(crcHash);
+
             stream.Position = position;
         }
 

--- a/src/PngImageWriter.cs
+++ b/src/PngImageWriter.cs
@@ -144,7 +144,14 @@ namespace ZXing.PngWriter
             var chunkTypePosition = _heightPosition - 8;
             stream.Position = chunkTypePosition;
             Span<byte> typeAndData = stackalloc byte[4 + 13];
-            stream.Read(typeAndData);
+            var totalRead = 0;
+            while (totalRead < typeAndData.Length)
+            {
+                var bytesRead = stream.Read(typeAndData.Slice(totalRead));
+                if (bytesRead == 0)
+                    throw new EndOfStreamException("Unable to read IHDR chunk data needed to recalculate CRC.");
+                totalRead += bytesRead;
+            }
             var crcHash = CRC.Crc32(typeAndData);
             stream.WriteUInt(crcHash);
 


### PR DESCRIPTION
## Summary
- Recalculate the IHDR chunk CRC after `UpdateHeight` writes the new height value
- Reads the chunk type (4 bytes) + chunk data (13 bytes) and recomputes CRC32 before writing it back
- Fixes PNG validity for readers that enforce CRC checks

Fixes #1

## Test plan
- [ ] Generate a PNG that triggers `UpdateHeight` (via `EnsureBlankScanLines`)
- [ ] Verify the resulting PNG opens in strict PNG readers (e.g., `pngcheck`)
- [ ] Confirm the IHDR chunk CRC matches expected value