### PR TITLE
Use cross-platform Vector APIs and ReadOnlySpan literals

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -17,9 +17,8 @@
 using System;
 using System.Buffers.Binary;
 using System.IO;
+using System.Numerics;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using ZXing.Common;
 
 namespace ZXing.PngWriter
@@ -55,151 +54,58 @@ namespace ZXing.PngWriter
 
         public static Span<byte> GetBytes(this BitArray bitArray) => MemoryMarshal.AsBytes<int>(bitArray.Array).Slice(0, bitArray.SizeInBytes);
 
-        public static unsafe void Negate(this Span<byte> span)
+        public static void Negate(this Span<byte> span)
         {
-            var bytesNegated = 0;
-            if (Avx2.IsSupported)
-            {
-                var vectorCount = span.Length / 32;
-                fixed (byte* ptr = span)
-                {
-                    for (int i = 0; i < vectorCount; i++)
-                    {
-                        var currentPtr = ptr + (i * 32);
-                        Avx.Store(currentPtr, Avx2.AndNot(Avx.LoadVector256(currentPtr), Vector256.Create(byte.MaxValue)));
-                        bytesNegated += 32;
-                    }
-                }
-            }
-            else if (Sse2.IsSupported)
-            {
-                var vectorCount = span.Length / 16;
-                fixed (byte* ptr = span)
-                {
-                    for (int i = 0; i < vectorCount; i++)
-                    {
-                        var currentPtr = ptr + (i * 16);
-                        Sse2.Store(currentPtr, Sse2.AndNot(Sse2.LoadVector128(currentPtr), Vector128.Create(byte.MaxValue)));
-                        bytesNegated += 16;
-                    }
-                }
-            }
-            for (int i = bytesNegated; i < span.Length; i++)
-            {
+            var vectors = MemoryMarshal.Cast<byte, Vector<byte>>(span);
+            var allOnes = Vector<byte>.AllBitsSet;
+            for (int i = 0; i < vectors.Length; i++)
+                vectors[i] = Vector.Xor(vectors[i], allOnes);
+            for (int i = vectors.Length * Vector<byte>.Count; i < span.Length; i++)
                 span[i] = (byte)~span[i];
-            }
         }
 
-        public static unsafe void Negate(this Span<int> span)
+        public static void Negate(this Span<int> span)
         {
-            var intsNegated = 0;
-            if (Avx2.IsSupported)
-            {
-                var vectorCount = span.Length / 8;
-                fixed (int* ptr = &span[0])
-                {
-                    for (int i = 0; i < vectorCount; i++)
-                    {
-                        var currentPtr = ptr + (i * 8);
-                        Avx.Store(currentPtr, Avx2.AndNot(Avx.LoadVector256(currentPtr), Vector256.Create(-1)));
-                        intsNegated += 8;
-                    }
-                }
-            }
-            else if (Sse2.IsSupported)
-            {
-                var vectorCount = span.Length / 4;
-                fixed (int* ptr = &span[0])
-                {
-                    for (int i = 0; i < vectorCount; i++)
-                    {
-                        var currentPtr = ptr + (i * 4);
-                        Sse2.Store(currentPtr, Sse2.AndNot(Sse2.LoadVector128(currentPtr), Vector128.Create(-1)));
-                        intsNegated += 4;
-                    }
-                }
-            }
-            for (int i = intsNegated; i < span.Length; i++)
-            {
+            var vectors = MemoryMarshal.Cast<int, Vector<int>>(span);
+            var allOnes = Vector<int>.AllBitsSet;
+            for (int i = 0; i < vectors.Length; i++)
+                vectors[i] = Vector.Xor(vectors[i], allOnes);
+            for (int i = vectors.Length * Vector<int>.Count; i < span.Length; i++)
                 span[i] = ~span[i];
-            }
         }
 
-        public static unsafe void ReverseBits(this Span<int> span)
+        public static void ReverseBits(this Span<int> span)
         {
-            var intsReversed = 0;
-
-            if (Avx2.IsSupported)
-            {
-                fixed (int* ptr = span)
-                {
-                    var vectorCount = span.Length / 8;
-                    for (int i = 0; i < vectorCount; i++)
-                    {
-
-                        var vector = Avx.LoadVector256((ptr + intsReversed));
-                        var vector2 = Avx2.And(Avx2.And(vector, Vector256.Create(0xFF00FF)), Vector256.Create(-16711936));
-                        vector =
-                            Avx2.Add(
-                                Avx2.Or(
-                                    Avx2.ShiftRightLogical(vector, 8),
-                                    Avx2.ShiftLeftLogical(vector, 24)
-                                ),
-                                Avx2.Or(
-                                    Avx2.ShiftLeftLogical(vector2, 8),
-                                    Avx2.ShiftRightLogical(vector2, 24)
-                                 )
-                            );
-
-                        Avx.Store(ptr + intsReversed, vector);
-                        intsReversed += 8;
-                    }
-                }
-            }
-
-            for (int i = intsReversed; i < span.Length; i++)
-            {
+            for (int i = 0; i < span.Length; i++)
                 span[i] = BinaryPrimitives.ReverseEndianness(span[i]);
-            }
-
-            fixed (void* ptr = span)
-            {
-                new Span<byte>(ptr, span.Length * 4).ReverseBits();
-            }
+            MemoryMarshal.AsBytes(span).ReverseBits();
         }
 
-        static readonly Vector256<ushort> BitShiftMask_F0F0 = Vector256.Create((ushort)0xF0F0);
-        static readonly Vector256<ushort> BitShiftMask_0F0F = Vector256.Create((ushort)0x0F0F);
-        static readonly Vector256<ushort> BitShiftMask_CCCC = Vector256.Create((ushort)0xCCCC);
-        static readonly Vector256<ushort> BitShiftMask_3333 = Vector256.Create((ushort)0x3333);
-        static readonly Vector256<ushort> BitShiftMask_AAAA = Vector256.Create((ushort)0xAAAA);
-        static readonly Vector256<ushort> BitShiftMask_5555 = Vector256.Create((ushort)0x5555);
-
-        public static unsafe void ReverseBits(this Span<byte> span)
+        public static void ReverseBits(this Span<byte> span)
         {
-            var bytesReversed = 0;
-
-            if (Avx2.IsSupported)
+            var vectors = MemoryMarshal.Cast<byte, Vector<byte>>(span);
+            var mask_F0 = new Vector<byte>(0xF0);
+            var mask_0F = new Vector<byte>(0x0F);
+            var mask_CC = new Vector<byte>(0xCC);
+            var mask_33 = new Vector<byte>(0x33);
+            var mask_AA = new Vector<byte>(0xAA);
+            var mask_55 = new Vector<byte>(0x55);
+            for (int i = 0; i < vectors.Length; i++)
             {
-                fixed (byte* ptr = span)
-                {
-                    var vectorCount = span.Length / 32;
-                    for (int i = 0; i < vectorCount; i++)
-                    {
-                        var vector = Avx.LoadVector256((ushort*)(ptr + bytesReversed));
-                        vector = Avx2.Or(Avx2.ShiftRightLogical(Avx2.And(vector, BitShiftMask_F0F0), 4), Avx2.ShiftLeftLogical(Avx2.And(vector, BitShiftMask_0F0F), 4));
-                        vector = Avx2.Or(Avx2.ShiftRightLogical(Avx2.And(vector, BitShiftMask_CCCC), 2), Avx2.ShiftLeftLogical(Avx2.And(vector, BitShiftMask_3333), 2));
-                        vector = Avx2.Or(Avx2.ShiftRightLogical(Avx2.And(vector, BitShiftMask_AAAA), 1), Avx2.ShiftLeftLogical(Avx2.And(vector, BitShiftMask_5555), 1));
-                        Avx.Store((ushort*)(ptr + bytesReversed), vector);
-                        bytesReversed += 32;
-                    }
-                }
+                var v = vectors[i];
+                v = Vector.BitwiseOr(
+                    Vector.BitwiseAnd(Vector.ShiftRightLogical(v, 4), mask_0F),
+                    Vector.ShiftLeft(Vector.BitwiseAnd(v, mask_0F), 4));
+                v = Vector.BitwiseOr(
+                    Vector.BitwiseAnd(Vector.ShiftRightLogical(v, 2), mask_33),
+                    Vector.ShiftLeft(Vector.BitwiseAnd(v, mask_33), 2));
+                v = Vector.BitwiseOr(
+                    Vector.BitwiseAnd(Vector.ShiftRightLogical(v, 1), mask_55),
+                    Vector.ShiftLeft(Vector.BitwiseAnd(v, mask_55), 1));
+                vectors[i] = v;
             }
-
-            for (int i = bytesReversed; i < span.Length; i++)
-            {
+            for (int i = vectors.Length * Vector<byte>.Count; i < span.Length; i++)
                 span[i] = span[i].ReverseBits();
-            }
         }
     }
 }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -84,11 +84,8 @@ namespace ZXing.PngWriter
         public static void ReverseBits(this Span<byte> span)
         {
             var vectors = MemoryMarshal.Cast<byte, Vector<byte>>(span);
-            var mask_F0 = new Vector<byte>(0xF0);
             var mask_0F = new Vector<byte>(0x0F);
-            var mask_CC = new Vector<byte>(0xCC);
             var mask_33 = new Vector<byte>(0x33);
-            var mask_AA = new Vector<byte>(0xAA);
             var mask_55 = new Vector<byte>(0x55);
             for (int i = 0; i < vectors.Length; i++)
             {

--- a/src/PngImageWriter.cs
+++ b/src/PngImageWriter.cs
@@ -113,7 +113,7 @@ namespace ZXing.PngWriter
                 _toDeflateStream.CopyTo(deflateStream);
             }
             var deflatedBuffer = deflateBackingStream.GetBuffer().AsSpan().Slice(0, (int)deflateBackingStream.Length);
-            WriteChunk(datType, deflatedBuffer);
+            WriteChunk(DatType, deflatedBuffer);
             _toDeflateStream.Dispose();
             _toDeflateStream = null;
 
@@ -157,11 +157,11 @@ namespace ZXing.PngWriter
 
         public void Dispose() => _toDeflateStream?.Dispose();
 
-        private static readonly byte[] pngSignature = new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 };
+        private static ReadOnlySpan<byte> PngSignature => [137, 80, 78, 71, 13, 10, 26, 10];
 
         private void WritePngHeader() =>
             // write png signature
-            Stream.Write(pngSignature);
+            Stream.Write(PngSignature);
 
         private void WriteHdr(int width, int height) => WriteHdr((uint)width, (uint)height);
 
@@ -211,20 +211,18 @@ namespace ZXing.PngWriter
             // interlace method (1 byte)
             hdrData[12] = 0;
 
-            WriteChunk(hdrType, hdrData);
+            WriteChunk(HdrType, hdrData);
         }
 
-        private static readonly byte[] datType = new[] { (byte)'I', (byte)'D', (byte)'A', (byte)'T' };
-        private static readonly byte[] hdrType = new[] { (byte)'I', (byte)'H', (byte)'D', (byte)'R' };
-        private static readonly byte[] endType = new[] { (byte)'I', (byte)'E', (byte)'N', (byte)'D' };
+        private static ReadOnlySpan<byte> DatType => "IDAT"u8;
+        private static ReadOnlySpan<byte> HdrType => "IHDR"u8;
+        private static ReadOnlySpan<byte> EndType => "IEND"u8;
 
-        private void WriteEnd() =>
-            //var endTypeAndData = new[] { (byte)'I', (byte)'E', (byte)'N', (byte)'D' };
-            WriteChunk(endType);
+        private void WriteEnd() => WriteChunk(EndType);
 
-        private void WriteChunk(Span<byte> chunkType) => WriteChunk(chunkType, Span<byte>.Empty);
+        private void WriteChunk(ReadOnlySpan<byte> chunkType) => WriteChunk(chunkType, ReadOnlySpan<byte>.Empty);
 
-        private void WriteChunk(Span<byte> chunkType, Span<byte> chunkData)
+        private void WriteChunk(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> chunkData)
         {
             /*
              *  ┌─────────┬─────────────┬────────────┬────────────────────┐

--- a/src/TextualInformation.cs
+++ b/src/TextualInformation.cs
@@ -109,9 +109,9 @@ namespace ZXing.PngWriter
 
         public static implicit operator TextData(string value) => new TextData(value);
 
-        private static readonly byte[] tEXt = new byte[] { (byte)'t', (byte)'E', (byte)'X', (byte)'t' };
-        private static readonly byte[] zTXt = new byte[] { (byte)'z', (byte)'T', (byte)'X', (byte)'t' };
-        private static readonly byte[] iTXt = new byte[] { (byte)'i', (byte)'T', (byte)'X', (byte)'t' };
+        private static readonly byte[] tEXt = "tEXt"u8.ToArray();
+        private static readonly byte[] zTXt = "zTXt"u8.ToArray();
+        private static readonly byte[] iTXt = "iTXt"u8.ToArray();
 
         private static readonly Encoding Latin1Encoder = Encoding.GetEncoding("Latin1");
 

--- a/src/ZXing.PngWriter.csproj
+++ b/src/ZXing.PngWriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <nullable>enable</nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
     <Authors>Craig Beaumont</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/tests/ZXing.PngWriter.Tests.csproj
+++ b/tests/ZXing.PngWriter.Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #7
Closes #9